### PR TITLE
Failed authorisation notification marks payment as failed

### DIFF
--- a/features/shop/paying_with_adyen_during_checkout.feature
+++ b/features/shop/paying_with_adyen_during_checkout.feature
@@ -58,3 +58,12 @@ Feature: Paying with Adyen during checkout
         When I confirm my order with Adyen payment
         Then I should get a notification of a successful transaction
         And Payment status should has been completed
+
+    @ui
+    Scenario: Failed payment notification should mark the payment as failed
+        Given I added product "PHP T-Shirt" to the cart
+        And I have proceeded selecting "Adyen" payment method
+        And I confirm my order with Adyen payment
+        When I cancel my Adyen payment
+        Then I should get a notification of a failed transaction
+        And the payment status should be failed

--- a/src/Action/NotifyAction.php
+++ b/src/Action/NotifyAction.php
@@ -78,7 +78,7 @@ final class NotifyAction implements ActionInterface, ApiAwareInterface, GatewayA
             if (AdyenBridgeInterface::AUTHORISATION === $httpRequest->request['eventCode']) {
                 if (true === filter_var($httpRequest->request['success'], FILTER_VALIDATE_BOOLEAN)) {
                     $httpRequest->request['authResult'] = AdyenBridgeInterface::AUTHORISED;
-                } elseif (!empty($httpRequest->request['reason'])) {
+                } else {
                     $httpRequest->request['authResult'] = AdyenBridgeInterface::REFUSED;
                 }
             }

--- a/tests/Behat/Context/Ui/Shop/AdyenCheckoutContext.php
+++ b/tests/Behat/Context/Ui/Shop/AdyenCheckoutContext.php
@@ -104,6 +104,14 @@ final class AdyenCheckoutContext implements Context
     }
 
     /**
+     * @Then /^I should get a notification of a failed transaction$/
+     */
+    public function iShouldGetANotificationOfAFailedTransaction()
+    {
+        $this->adyenCheckoutPage->failedAuthorisationWithoutReasonNotify();
+    }
+
+    /**
      * @Then Payment status should has been completed
      */
     public function paymentStatusShouldHasBeenCompleted(): void
@@ -116,5 +124,17 @@ final class AdyenCheckoutContext implements Context
         foreach ($payments as $payment) {
             Assert::true(PaymentInterface::STATE_COMPLETED === $payment->getState());
         }
+    }
+
+    /**
+     * @Given /^the payment status should be failed/
+     */
+    public function thePaymentStatusShouldBeFailed()
+    {
+        /** @var PaymentInterface $payment */
+        $payment = $this->paymentRepository->findOneBy([]);
+
+        Assert::notNull($payment, 0);
+        Assert::eq($payment->getState(), PaymentInterface::STATE_FAILED);
     }
 }

--- a/tests/Behat/Page/External/AdyenCheckoutPage.php
+++ b/tests/Behat/Page/External/AdyenCheckoutPage.php
@@ -180,6 +180,23 @@ final class AdyenCheckoutPage extends Page implements AdyenCheckoutPageInterface
     /**
      * {@inheritDoc}
      */
+    public function failedAuthorisationWithoutReasonNotify(): void
+    {
+        $token = $this->findToken('notify');
+
+        $data = $this->notifyData;
+        $data['eventCode'] = 'AUTHORISATION';
+        $data['success'] = 'false';
+        $data['reason'] = '';
+        $data['merchantReference'] = $this->createMerchantReferenceWithToken($token);
+        $data['additionalData_hmacSignature'] = $this->adyenBridge->createSignatureForNotification($data);
+
+        $this->client->request('POST', '/payment/adyen/notify', $data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     protected function getUrl(array $urlParameters = []): string
     {
         return 'https://test.adyen.com/hpp/pay.shtml';

--- a/tests/Behat/Page/External/AdyenCheckoutPageInterface.php
+++ b/tests/Behat/Page/External/AdyenCheckoutPageInterface.php
@@ -40,6 +40,12 @@ interface AdyenCheckoutPageInterface extends PageInterface
      * @throws UnsupportedDriverActionException
      * @throws DriverException
      */
+    public function failedAuthorisationWithoutReasonNotify(): void;
+
+    /**
+     * @throws UnsupportedDriverActionException
+     * @throws DriverException
+     */
     public function successRefundedPaymentNotify(): void;
 
     /**


### PR DESCRIPTION
The authorisation should be considered successful only when `success = true` and failed otherwise.
The `reason` field is not necessarily populated when `success = false`, so it should not be used to determine wherever the authorisation failed.
https://docs.adyen.com/development-resources/webhooks/understand-notifications

Fixes #17  