### PR TITLE
Fix for refunds

### DIFF
--- a/src/Resources/config/services/payment_processing.yml
+++ b/src/Resources/config/services/payment_processing.yml
@@ -1,5 +1,6 @@
 services:
     bitbag_sylius_adyen_plugin.payment_processing.refund:
+        public: true
         class: BitBag\SyliusAdyenPlugin\PaymentProcessing\RefundPaymentProcessor
         arguments:
             - "@payum"


### PR DESCRIPTION
Refund processor needs to be a public service - so it can be used by state machine in :
https://github.com/BitBagCommerce/SyliusAdyenPlugin/blob/master/src/Resources/config/state_machine/sylius_payment.yml#L7
(This broke in symfony 3.4 https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default )